### PR TITLE
Fix Windows request seed overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Upstream bump from vLLM 0.23.0 to **vLLM 0.24.0**, still targeting
 Python 3.13, CUDA 12.8, PyTorch 2.11.0+cu128, and
 `TORCH_CUDA_ARCH_LIST=8.6;8.9;12.0`.
 
+### 2026-07-17 Windows sampling hotfix
+
+- Fixed the follow-up failure reported in issue #10:
+  `ValueError: low is out of bounds for int32` during request sampling.
+- Requested NumPy's explicit `int64` output when vLLM generates a seed across
+  the full signed 64-bit range. NumPy otherwise defaults to a C `long`, which
+  remains 32-bit on 64-bit Windows.
+- Added source, patch, and wheel regression guards and repacked the release
+  wheel. Final wheel SHA-256:
+  `41E930FBCF994E4FD7E5CB1585F8D277AF3FFDBA0AEE7F5DDE5822DD90E6FBA7`.
+
 ### 2026-07-12 reliability audit
 
 - Fixed issue #8 by replacing fragile PowerShell stdout hash capture with a
@@ -33,7 +44,7 @@ Python 3.13, CUDA 12.8, PyTorch 2.11.0+cu128, and
   engine output dispatch.
 - Repacked the vLLM wheel with Windows-safe process-tree shutdown and a clear
   `--uds` rejection. Final wheel SHA-256:
-  `A3C324281E5BE9D8FEAF0BE50B50DCE08F3FCDE56E3F74129A128D3B1A49645B`.
+  `41E930FBCF994E4FD7E5CB1585F8D277AF3FFDBA0AEE7F5DDE5822DD90E6FBA7`.
 
 ### 2026-07-12 legacy PowerShell bootstrap fix
 
@@ -105,7 +116,7 @@ Python 3.13, CUDA 12.8, PyTorch 2.11.0+cu128, and
 - Verified intentionally skipped paths report unavailable:
   `has_deep_gemm=False` and `has_cooperative_topk=False`.
 - Wheel SHA256:
-  `A3C324281E5BE9D8FEAF0BE50B50DCE08F3FCDE56E3F74129A128D3B1A49645B`.
+  `41E930FBCF994E4FD7E5CB1585F8D277AF3FFDBA0AEE7F5DDE5822DD90E6FBA7`.
 
 ## v0.23.0-win-cu128 - 2026-06-30
 

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -26,8 +26,8 @@ see [docs/build.md](docs/build.md).
 ## Diff stats
 
 ```
-v8 patch size: ~125 KB unified diff against upstream v0.24.0.
-SHA-256: 799361D8708E8D8B2B343913C5A1FE88DA1102BDE403CEB228CB77D5FF9A0218
+v8 patch size: 125,230 bytes unified diff against upstream v0.24.0.
+SHA-256: 630ADF8A49430C44195FBDD468D02AD554F9B2936E5EC0AB34E6DFC765C142E2
 + 3 new files: vllm/v1/attention/ops/multi_turboquant_kv.py (295 lines),
   cutlass-windows.patch (69 lines),
   vllm-flash-attn-cutlass-windows.patch (69 lines)
@@ -45,6 +45,7 @@ These hunks were added on top of the v0.23.0 Windows/cu128 work:
 | Runtime Python | `vllm/model_executor/layers/sparse_attn_indexer.py` | Guard `torch.ops._C.cooperative_topk` so sparse attention falls back when the optional op is absent |
 | Runtime Python | `vllm/platforms/cuda.py` | Suppress the expected missing `_qutlass_C` warning on Windows while preserving warnings for real import failures |
 | Runtime Python | `vllm/utils/system_utils.py`, `vllm/entrypoints/openai/api_server.py` | Terminate process trees through psutil instead of unavailable `SIGKILL`; reject `--uds` clearly when Windows Python has no `AF_UNIX` |
+| Runtime Python | `vllm/v1/worker/gpu/sample/states.py` | Request explicit NumPy `int64` output for the full-range random request seed; Windows C `long` is only 32-bit |
 | Rust packaging | `setup.py` | Recognize `vllm-rs.exe` and `_rust_*.pyd` as prebuilt Rust artifacts on Windows |
 | Wheel packaging | `assemble_wheel_cu128_v0.24.0.py` | Assembles the already-built tree into a cp313/cu128 wheel including `_rust_tool_parser.pyd`, `vllm-rs.exe`, `triton_kernels`, `fmha_sm100`, and generated FlashAttention rotary/CuteDSL Python payloads |
 | Requirements | `requirements/cuda.txt` | Keep Linux-only CUDA helper packages out of the Windows install path: FlashInfer, TVM FFI, TileLang, CUDNN frontend, CUTLASS DSL, QuACK, TokenSpeed-MLA, Humming kernels, and fastsafetensors |
@@ -117,6 +118,7 @@ These hunks were added on top of the original cu126 patch for the
 | Runtime Python | `vllm/utils/network_utils.py` | 1 | ZMQ IPC → `tcp://127.0.0.1` |
 | Runtime Python | `vllm/utils/system_utils.py` | 1 | Force `spawn` multiprocessing |
 | Runtime Python | `vllm/v1/engine/core_client.py` | 1 | Force `InprocClient` |
+| Runtime Python | `vllm/v1/worker/gpu/sample/states.py` | 1 | Force `np.int64` seed generation for the full signed 64-bit range on Windows |
 | Runtime Python | `vllm/v1/utils.py` | 1 | `import uvloop` → try/except with asyncio fallback |
 | TQ integration | `vllm/config/cache.py` | 1 | Add 6 TQ entries to `CacheDType` literal (alongside upstream's 4 `turboquant_*`) |
 | TQ integration | `vllm/utils/torch_utils.py` | 1 | Map our 6 TQ dtypes to `torch.uint8` |

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ and Multi-TurboQuant integration.
   upstream editable-build copy step dropped on Windows. The v8 patch makes
   that copy path platform-independent, and the assembler now rejects an
   incomplete FlashAttention payload.
+- **Windows request sampling fixed** - NumPy now generates the full-range
+  internal request seed explicitly as `int64`, avoiding the 32-bit C `long`
+  default that caused issue #10's follow-up error on 64-bit Windows.
 - **Smoke tested from the final wheel** - installed the assembled wheel,
   imported `vllm`, the stable libtorch CUDA extensions, FA2, `spinloop`,
   `cumem_allocator`, `_rust_tool_parser`, OpenAI API server / DP supervisor
@@ -211,7 +214,7 @@ and `multi_turboquant-0.1.0-py3-none-any.whl` from the Releases page, then:
 
 | Artifact | SHA-256 |
 |---|---|
-| `vllm-0.24.0+cu128-cp313-cp313-win_amd64.whl` | `A3C324281E5BE9D8FEAF0BE50B50DCE08F3FCDE56E3F74129A128D3B1A49645B` |
+| `vllm-0.24.0+cu128-cp313-cp313-win_amd64.whl` | `41E930FBCF994E4FD7E5CB1585F8D277AF3FFDBA0AEE7F5DDE5822DD90E6FBA7` |
 | `multi_turboquant-0.1.0-py3-none-any.whl` | `5B310E05904B588539D9A8E3374DFA6C160F025F9C2099BA5C7877C79B2FA149` |
 
 ```batch

--- a/assemble_wheel_cu128_v0.24.0.py
+++ b/assemble_wheel_cu128_v0.24.0.py
@@ -48,6 +48,7 @@ REQUIRED_FILES = [
     "LICENSE",
 ]
 REQUIRED_ARCHIVE_FILES = {
+    "vllm/v1/worker/gpu/sample/states.py",
     "vllm/vllm_flash_attn/layers/__init__.py",
     "vllm/vllm_flash_attn/layers/rotary.py",
     "vllm/vllm_flash_attn/ops/__init__.py",
@@ -66,6 +67,9 @@ REQUIRED_NONEMPTY_FILES = {
     "vllm/vllm_flash_attn/_vllm_fa2_C.pyd",
     "vllm/vllm-rs.exe",
 }
+
+SAMPLING_STATES = "vllm/v1/worker/gpu/sample/states.py"
+INT64_SEED_FIX = b"_NP_INT64_MIN, _NP_INT64_MAX, dtype=np.int64"
 
 
 def digest(data: bytes) -> str:
@@ -172,6 +176,15 @@ def validate_source() -> list[str]:
         if path.is_file() and path.stat().st_size == 0:
             errors.append(f"required binary is empty: {path}")
 
+    sampling_states = SRC / SAMPLING_STATES
+    if not sampling_states.is_file():
+        errors.append(f"missing sampling state source: {sampling_states}")
+    elif INT64_SEED_FIX not in sampling_states.read_bytes():
+        errors.append(
+            "sampling seed generation does not request np.int64; "
+            "the wheel would fail on Windows"
+        )
+
     metadata_path = SRC / "vllm.egg-info" / "PKG-INFO"
     if metadata_path.is_file():
         metadata = BytesParser().parsebytes(metadata_path.read_bytes())
@@ -198,6 +211,9 @@ def validate_wheel(path: Path) -> None:
         missing = REQUIRED_ARCHIVE_FILES - set(names)
         if missing:
             raise ValueError(f"missing required wheel payloads: {sorted(missing)}")
+
+        if INT64_SEED_FIX not in wheel.read(SAMPLING_STATES):
+            raise ValueError("wheel is missing the Windows int64 sampling-seed fix")
 
         cute_files = [
             name

--- a/docs/build.md
+++ b/docs/build.md
@@ -130,6 +130,10 @@ Validate archive completeness and RECORD before installing:
 python tests\test_wheel_contents.py dist-v8\vllm-0.24.0+cu128-cp313-cp313-win_amd64.whl
 ```
 
+The assembler and wheel-content test also verify that request-seed generation
+explicitly uses NumPy `int64`, preventing the Windows 32-bit C `long` overflow
+reported in issue #10.
+
 Install the wheel from outside the source tree:
 
 ```bat

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,6 +4,18 @@ Common errors when building or running vLLM v0.24.0 on Windows.
 
 ## Runtime errors
 
+### `ValueError: low is out of bounds for int32` during request sampling
+
+This was the follow-up failure in issue #10. vLLM asks NumPy for a random seed
+across the full signed 64-bit range. NumPy's legacy `randint` API defaults to a
+C `long`, which is still 32-bit on 64-bit Windows, so the lower bound was
+rejected before a request could run.
+
+Pull the latest repository and rerun `install.bat`. The patched call now
+requests `dtype=np.int64` explicitly. This failure is separate from the
+original Python/Triton error in issue #10: changing to Python 3.10, 3.11, or
+3.12 alone is not a proven fix for this Windows integer-width bug.
+
 ### `Get-FileHash` is not recognized
 
 This was issue #9. Some Windows PowerShell environments do not expose the
@@ -25,11 +37,11 @@ rejecting a valid wheel.
 
 Pull the latest repository and rerun `install.bat`. Hashing now runs through
 `verify_artifact.py`, reports size and SHA-256 directly, and replaces stale or
-truncated wheels automatically. The current wheel is exactly 319,115,748 bytes
+truncated wheels automatically. The current wheel is exactly 319,115,760 bytes
 with SHA-256:
 
 ```text
-A3C324281E5BE9D8FEAF0BE50B50DCE08F3FCDE56E3F74129A128D3B1A49645B
+41E930FBCF994E4FD7E5CB1585F8D277AF3FFDBA0AEE7F5DDE5822DD90E6FBA7
 ```
 
 ### `Failed to find Python libs` / `Python.h not found`
@@ -79,7 +91,7 @@ force-reinstall the wheel currently attached to `v0.24.0-win-cu128`. The
 corrected wheel SHA256 is:
 
 ```text
-A3C324281E5BE9D8FEAF0BE50B50DCE08F3FCDE56E3F74129A128D3B1A49645B
+41E930FBCF994E4FD7E5CB1585F8D277AF3FFDBA0AEE7F5DDE5822DD90E6FBA7
 ```
 
 Verify the repaired import with:

--- a/install.bat
+++ b/install.bat
@@ -31,8 +31,8 @@ set "TORCH_INDEX=https://download.pytorch.org/whl/cu128"
 REM Pre-built vLLM wheel (auto-downloaded into dist-v8\ if not present locally)
 set "WHEEL_NAME=vllm-0.24.0+cu128-cp313-cp313-win_amd64.whl"
 set "WHEEL_URL=https://github.com/aivrar/vllm-windows-build/releases/download/v0.24.0-win-cu128/vllm-0.24.0+cu128-cp313-cp313-win_amd64.whl"
-set "WHEEL_SHA256=A3C324281E5BE9D8FEAF0BE50B50DCE08F3FCDE56E3F74129A128D3B1A49645B"
-set "WHEEL_SIZE=319115748"
+set "WHEEL_SHA256=41E930FBCF994E4FD7E5CB1585F8D277AF3FFDBA0AEE7F5DDE5822DD90E6FBA7"
+set "WHEEL_SIZE=319115760"
 set "WHEEL_FILE=%~dp0dist-v8\%WHEEL_NAME%"
 set "WHEEL_PART=%~dp0dist-v8\%WHEEL_NAME%.part"
 

--- a/launch.bat
+++ b/launch.bat
@@ -11,7 +11,7 @@ REM ============================================================
 REM  Check Python installation
 REM ============================================================
 set "NEEDS_INSTALL=0"
-set "EXPECTED_WHEEL_SHA256=A3C324281E5BE9D8FEAF0BE50B50DCE08F3FCDE56E3F74129A128D3B1A49645B"
+set "EXPECTED_WHEEL_SHA256=41E930FBCF994E4FD7E5CB1585F8D277AF3FFDBA0AEE7F5DDE5822DD90E6FBA7"
 set "EXPECTED_MTQ_SHA256=5B310E05904B588539D9A8E3374DFA6C160F025F9C2099BA5C7877C79B2FA149"
 if not exist "%~dp0python\python.exe" set "NEEDS_INSTALL=1"
 if not exist "%~dp0python\.torch-installed" set "NEEDS_INSTALL=1"

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,7 +7,8 @@ python tests/test_wheel_contents.py dist-v8/vllm-0.24.0+cu128-cp313-cp313-win_am
 ```
 
 This check includes the generated FlashAttention rotary and CuteDSL modules that
-are not stored directly in the upstream vLLM source tree.
+are not stored directly in the upstream vLLM source tree. It also rejects a
+wheel missing issue #10's explicit NumPy `int64` request-seed fix.
 
 Run the installer/hash and concurrent engine-dispatch regressions with:
 

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -5,9 +5,9 @@ import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-VLLM_SHA256 = "A3C324281E5BE9D8FEAF0BE50B50DCE08F3FCDE56E3F74129A128D3B1A49645B"
+VLLM_SHA256 = "41E930FBCF994E4FD7E5CB1585F8D277AF3FFDBA0AEE7F5DDE5822DD90E6FBA7"
 MTQ_SHA256 = "5B310E05904B588539D9A8E3374DFA6C160F025F9C2099BA5C7877C79B2FA149"
-PATCH_SHA256 = "799361D8708E8D8B2B343913C5A1FE88DA1102BDE403CEB228CB77D5FF9A0218"
+PATCH_SHA256 = "630ADF8A49430C44195FBDD468D02AD554F9B2936E5EC0AB34E6DFC765C142E2"
 
 
 def batch_settings(path: Path) -> dict[str, str]:
@@ -28,7 +28,7 @@ class ReleaseContractTests(unittest.TestCase):
         self.assertEqual(install["MTQ_SHA256"], MTQ_SHA256)
         self.assertEqual(launch["EXPECTED_WHEEL_SHA256"], VLLM_SHA256)
         self.assertEqual(launch["EXPECTED_MTQ_SHA256"], MTQ_SHA256)
-        self.assertEqual(install["WHEEL_SIZE"], "319115748")
+        self.assertEqual(install["WHEEL_SIZE"], "319115760")
         self.assertEqual(install["MTQ_SIZE"], "136429")
 
     def test_installer_is_atomic_and_does_not_parse_hash_stdout(self) -> None:
@@ -75,6 +75,13 @@ class ReleaseContractTests(unittest.TestCase):
         from verify_artifact import sha256_file
 
         self.assertEqual(sha256_file(ROOT / "vllm-windows-v8.patch"), PATCH_SHA256)
+
+    def test_patch_forces_int64_sampling_seed(self) -> None:
+        patch = (ROOT / "vllm-windows-v8.patch").read_text(encoding="utf-8")
+        self.assertIn(
+            "+                _NP_INT64_MIN, _NP_INT64_MAX, dtype=np.int64",
+            patch,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_wheel_contents.py
+++ b/tests/test_wheel_contents.py
@@ -30,6 +30,7 @@ REQUIRED_RELEASE_FILES = REQUIRED_FLASH_ATTN_FILES | {
     "vllm/_rust_tool_parser.pyd",
     "vllm/cumem_allocator.pyd",
     "vllm/spinloop.pyd",
+    "vllm/v1/worker/gpu/sample/states.py",
     "vllm/vllm-rs.exe",
 }
 
@@ -39,6 +40,9 @@ REQUIRED_NONEMPTY_FILES = REQUIRED_RELEASE_FILES - {
     "vllm/vllm_flash_attn/ops/triton/__init__.py",
     "vllm/vllm_flash_attn/cute/__init__.py",
 }
+
+SAMPLING_STATES = "vllm/v1/worker/gpu/sample/states.py"
+INT64_SEED_FIX = b"_NP_INT64_MIN, _NP_INT64_MAX, dtype=np.int64"
 
 
 def sha256_record(data: bytes) -> str:
@@ -58,6 +62,10 @@ def validate_wheel(wheel_path: Path) -> None:
         assert not missing, f"missing release payloads: {missing}"
         for name in REQUIRED_NONEMPTY_FILES:
             assert wheel.getinfo(name).file_size > 0, f"empty release payload: {name}"
+
+        assert INT64_SEED_FIX in wheel.read(SAMPLING_STATES), (
+            "wheel is missing the Windows int64 sampling-seed fix"
+        )
 
         metadata_names = [name for name in names if name.endswith(".dist-info/METADATA")]
         assert len(metadata_names) == 1, f"expected one METADATA, found {metadata_names}"

--- a/vllm-windows-v8.patch
+++ b/vllm-windows-v8.patch
@@ -2944,3 +2944,14 @@ index 71ade9c86..9fbfb4c5d 100644
  from torch.autograd.profiler import record_function
  
  import vllm.envs as envs
+diff --git a/vllm/v1/worker/gpu/sample/states.py b/vllm/v1/worker/gpu/sample/states.py
+index fe4dee6a6..c25fbdf5f 100644
+--- a/vllm/v1/worker/gpu/sample/states.py
++++ b/vllm/v1/worker/gpu/sample/states.py
+@@ -52,3 +52,5 @@ class SamplingStates:
+         if seed is None:
+-            seed = np.random.randint(_NP_INT64_MIN, _NP_INT64_MAX)
++            seed = np.random.randint(
++                _NP_INT64_MIN, _NP_INT64_MAX, dtype=np.int64
++            )
+         self.seeds.np[req_idx] = seed


### PR DESCRIPTION
﻿## Summary

- request NumPy `int64` explicitly when vLLM creates an internal full-range request seed
- add assembler and wheel-content guards so the Windows fix cannot be omitted from a future wheel
- repack the cp313/cu128 wheel and synchronize installer, launcher, release-contract, and documentation digests

## Root cause

Issue #10's follow-up traceback is separate from the earlier Python 3.13.4 header bug. NumPy's legacy `RandomState.randint` defaults to a C `long`; that type is 32-bit on 64-bit Windows. vLLM passes the full signed 64-bit range, so NumPy rejects the lower bound before sampling. Passing `dtype=np.int64` selects the intended 64-bit path.

A search of upstream vLLM issues and pull requests found no existing report or change for this exact `states.py` call, so this does not duplicate known upstream work.

Related to #10.

## Validation

- `python -m unittest tests.test_verify_artifact tests.test_bootstrap_helpers tests.test_engine_dispatcher tests.test_release_contract tests.test_windows_runtime_guards -v` ? 16 tests passed
- `python tests/test_wheel_contents.py dist-v8/vllm-0.24.0+cu128-cp313-cp313-win_amd64.whl` ? passed
- `python -m py_compile` on the assembler, regression tests, and patched `states.py` ? passed
- applied `vllm-windows-v8.patch` to a fresh detached upstream `v0.24.0` worktree and ran `git diff --check` ? passed (the existing patch emits its known historical whitespace warnings while applying)
- reproduced `ValueError: low is out of bounds for int32` with the default NumPy call on Windows, then verified the same bounds return `numpy.int64` with `dtype=np.int64`

## Release artifacts

- wheel: `vllm-0.24.0+cu128-cp313-cp313-win_amd64.whl`
- wheel size: `319115760` bytes
- wheel SHA-256: `41E930FBCF994E4FD7E5CB1585F8D277AF3FFDBA0AEE7F5DDE5822DD90E6FBA7`
- patch size: `125230` bytes
- patch SHA-256: `630ADF8A49430C44195FBDD468D02AD554F9B2936E5EC0AB34E6DFC765C142E2`

The same-named wheel and patch assets on `v0.24.0-win-cu128` must be replaced after merge so the default branch's pinned hashes and the release downloads change together.

## AI assistance

OpenAI Codex was used to investigate the failure, implement the fix, rebuild the wheel, and run the validation above. The commit includes an `Assisted-by` trailer.
