### PR TITLE
Correct Windows performance quick starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Upstream bump from vLLM 0.23.0 to **vLLM 0.24.0**, still targeting
 Python 3.13, CUDA 12.8, PyTorch 2.11.0+cu128, and
 `TORCH_CUDA_ARCH_LIST=8.6;8.9;12.0`.
 
+### 2026-07-17 performance quick-start correction
+
+- Changed every Hello World example to the normal `kv_cache_dtype="auto"`
+  baseline. The previous README selected `isoquant4`, whose documented
+  unfused PyTorch fallback is 30-300× slower and is intended for offline or
+  memory-constrained workloads.
+- Stopped presenting `enforce_eager=True` as a throughput default; it is now
+  documented as a graph/compile compatibility option that disables normal
+  optimizations.
+- Synchronized the usage guide with `vllm_launcher.py`'s actual defaults and
+  added slow-generation troubleshooting guidance.
+- Removed the unsupported Windows `expandable_segments` recommendation, which
+  only produced a PyTorch warning and did not repair OOM conditions.
+
 ### 2026-07-17 Windows sampling hotfix
 
 - Fixed the follow-up failure reported in issue #10:

--- a/README.md
+++ b/README.md
@@ -287,8 +287,7 @@ Full instructions, including all the env vars and prerequisites:
 
 ```python
 import os
-# Required on Windows
-os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+os.environ["VLLM_HOST_IP"] = "127.0.0.1"
 
 # CUDA + torch DLL search paths
 os.add_dll_directory(r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8\bin")
@@ -301,21 +300,24 @@ os.add_dll_directory(r"C:\path\to\venv\Lib\site-packages\torch\lib")
 from vllm import LLM, SamplingParams
 
 llm = LLM(
-    model=r"E:\models\Qwen3-14B-AWQ-4bit",
+    model=r"E:\models\Qwen2.5-0.5B-Instruct",
     dtype="float16",
-    kv_cache_dtype="isoquant4",   # 2× KV cache capacity, near-FP16 quality
-    max_model_len=2048,
-    gpu_memory_utilization=0.85,
-    enforce_eager=True,
-    trust_remote_code=True,
+    kv_cache_dtype="auto",        # Fast FP16 baseline
+    max_model_len=512,
+    gpu_memory_utilization=0.5,
 )
 
 outputs = llm.generate(
     ["Explain CUDA streams in three sentences:"],
-    SamplingParams(temperature=0.7, max_tokens=200),
+    SamplingParams(temperature=0.0, max_tokens=32, seed=0),
 )
 print(outputs[0].outputs[0].text)
 ```
+
+`auto` is deliberate here: it establishes normal baseline performance. The
+first request can include one-time JIT or CUDA-graph setup, so benchmark a
+second request in the same process. Add `enforce_eager=True` only when
+diagnosing graph/compile compatibility; it disables those optimizations.
 
 For OpenAI-compatible HTTP serving and more usage patterns:
 **→ [docs/usage.md](docs/usage.md)**
@@ -336,7 +338,7 @@ library and run on the patched `TritonAttention` backend.
 | `turboquant_4bit_nc` | 4.25 | upstream | none | Upstream default |
 | `turboquant_k3v4_nc` | 3.25 / 4.25 | upstream | none | More aggressive K |
 | `turboquant_3bit_nc` | 3.25 | upstream | none | Most aggressive upstream |
-| `isoquant4` | 4.25 | quaternion 4D rotation | none | **Recommended default (ours)** |
+| `isoquant4` | 4.25 | quaternion 4D rotation | none | Quality-first local TQ; offline/memory-first use |
 | `planarquant4` | 4.25 | Givens 2D rotation | none | Same memory, simpler transform |
 | `isoquant3` | 3.25 | quaternion 4D rotation | none | More aggressive |
 | `planarquant3` | 3.25 | Givens 2D rotation | none | More aggressive |

--- a/VLLM.md
+++ b/VLLM.md
@@ -26,7 +26,6 @@ Starts an OpenAI-compatible server at `http://127.0.0.1:8000`.
 ```python
 import os
 
-os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 os.environ["VLLM_HOST_IP"] = "127.0.0.1"
 
 os.add_dll_directory(r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8\bin")
@@ -35,21 +34,23 @@ os.add_dll_directory(r"C:\path\to\venv\Lib\site-packages\torch\lib")
 from vllm import LLM, SamplingParams
 
 llm = LLM(
-    model=r"E:\models\Qwen3-14B-AWQ-4bit",
+    model=r"E:\models\Qwen2.5-0.5B-Instruct",
     dtype="float16",
-    kv_cache_dtype="isoquant4",
-    max_model_len=2048,
-    gpu_memory_utilization=0.85,
-    enforce_eager=True,
-    trust_remote_code=True,
+    kv_cache_dtype="auto",
+    max_model_len=512,
+    gpu_memory_utilization=0.5,
 )
 
 outputs = llm.generate(
     ["Explain CUDA streams in 3 sentences:"],
-    SamplingParams(temperature=0.7, max_tokens=200),
+    SamplingParams(temperature=0.0, max_tokens=32, seed=0),
 )
 print(outputs[0].outputs[0].text)
 ```
+
+Use `auto` for the fast baseline and measure a second request after one-time
+kernel/graph setup. `enforce_eager=True` is a compatibility/debugging option,
+not a throughput default.
 
 ## KV Cache Compression Options
 
@@ -63,7 +64,7 @@ Pass any of these as `kv_cache_dtype`:
 | `turboquant_4bit_nc` | Upstream TurboQuant |
 | `turboquant_k3v4_nc` | Upstream TurboQuant |
 | `turboquant_3bit_nc` | Upstream TurboQuant |
-| `isoquant4` | Multi-TurboQuant, recommended local default |
+| `isoquant4` | Multi-TurboQuant, quality-first memory option; slow fallback path |
 | `planarquant4` | Multi-TurboQuant |
 | `isoquant3` | Multi-TurboQuant |
 | `planarquant3` | Multi-TurboQuant |
@@ -74,10 +75,9 @@ The upstream `turboquant_*` variants use fused Triton kernels. The 6
 Multi-TurboQuant methods use a slower PyTorch fallback path but preserve
 the memory savings.
 
-## Required Windows Env Vars
+## Recommended Windows Environment
 
 ```batch
-set PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 set VLLM_HOST_IP=127.0.0.1
 ```
 

--- a/build.bat
+++ b/build.bat
@@ -202,9 +202,10 @@ call :requireArtifact "vllm\third_party\fmha_sm100" || exit /b 1
 echo.
 echo Build complete!
 echo.
-echo Required environment variables for running vLLM on Windows:
-echo   set PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+echo Recommended environment for single-rank vLLM on Windows:
 echo   set VLLM_HOST_IP=127.0.0.1
+echo Use kv_cache_dtype=auto for the fast baseline.
+echo Enable enforce_eager only for graph/compile troubleshooting.
 echo.
 
 endlocal

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -127,7 +127,6 @@ gap. The wiring is in place — the optimization is the next milestone.
 ```bat
 set VLLM_MODEL_PATH=E:\models\Qwen3-14B-abliterated-AWQ-4bit
 set VLLM_PYTHON=E:\vllm-windows-build\venv\Scripts\python.exe
-set PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 
 REM Smoke test (~30 sec)
 %VLLM_PYTHON% tests\test_v19.py

--- a/docs/install.md
+++ b/docs/install.md
@@ -158,12 +158,15 @@ dist-v8\vllm-0.24.0+cu128-cp313-cp313-win_amd64.whl
 
 ## Runtime Environment
 
-These are recommended before running models:
+Keep single-rank Windows initialization on the loopback interface:
 
 ```bat
-set PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 set VLLM_HOST_IP=127.0.0.1
 ```
+
+Do not set `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` for this Windows
+build. PyTorch reports that expandable segments are unsupported on this
+platform, so the setting only adds a warning and does not repair an OOM.
 
 For multi-GPU systems, set the CUDA device ordering explicitly:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,6 +16,35 @@ requests `dtype=np.int64` explicitly. This failure is separate from the
 original Python/Triton error in issue #10: changing to Python 3.10, 3.11, or
 3.12 alone is not a proven fix for this Windows integer-width bug.
 
+### A small model generates at only `0.01`-`0.3` tokens/s
+
+Check the startup line beginning with `non-default arg`. If it contains
+`kv_cache_dtype: 'isoquant4'` (or another local Multi-TurboQuant dtype), the
+engine is using the current unfused PyTorch encode/decode fallback. That path
+reduces KV-cache memory but is intentionally 30-300× slower than the normal
+`auto` baseline. It is for offline or memory-constrained workloads, not a
+Hello World performance test.
+
+Use the fast baseline first:
+
+```python
+llm = LLM(
+    model=r"E:\models\Qwen2.5-0.5B-Instruct",
+    dtype="float16",
+    kv_cache_dtype="auto",
+    max_model_len=512,
+    gpu_memory_utilization=0.5,
+)
+params = SamplingParams(temperature=0.0, max_tokens=32, seed=0)
+```
+
+Measure a second request in the same process after one-time JIT and CUDA-graph
+setup. `enforce_eager=True` can help isolate a graph/compile compatibility
+problem, but it disables those optimizations and should not be treated as the
+throughput default. In vLLM's progress display, the final `output` rate is the
+generation rate; a very low `input` rate can simply reflect the full elapsed
+request time.
+
 ### `Get-FileHash` is not recognized
 
 This was issue #9. Some Windows PowerShell environments do not expose the
@@ -142,25 +171,22 @@ error you may have an older patched build. Re-apply
 
 ### `torch.OutOfMemoryError: CUDA out of memory. ... X GiB is free` <a id="oom-with-free-gpu"></a>
 
-PyTorch's caching allocator can't satisfy a contiguous allocation even
-when the GPU has plenty of free memory. This is fragmentation.
-
-**Fix**: enable expandable segments before importing vLLM:
+PyTorch's caching allocator may be unable to satisfy an allocation even when
+the GPU appears to have free memory. On Windows, PyTorch reports
+`expandable_segments not supported on this platform`, so the commonly shared
+allocator setting does not fix this condition. Clear it if it is present:
 
 ```bat
-set PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+set PYTORCH_CUDA_ALLOC_CONF=
 ```
 
-Or in Python:
+Then lower vLLM's reservation and concurrency settings:
 
-```python
-import os
-os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
-import vllm  # must be after the env var
-```
-
-If you still get OOM, lower `gpu_memory_utilization` (try 0.5 first,
-then 0.4).
+1. Lower `gpu_memory_utilization` (try 0.5, then 0.4).
+2. Reduce `max_num_seqs` and `max_model_len`.
+3. Close other GPU processes and keep the Windows pagefile enabled.
+4. Use a compressed KV dtype only when its documented throughput trade-off is
+   acceptable.
 
 ### `ValueError: not enough values to unpack (expected 2, got 1)` in `torch.unique`
 

--- a/docs/turboquant.md
+++ b/docs/turboquant.md
@@ -109,7 +109,9 @@ In general:
 - The **3-bit / 2-bit** variants have visible noise — outputs may
   diverge from the baseline early.
 - The **4-bit** variants (`isoquant4`, `planarquant4`) stay much closer
-  to the baseline. They're the safe default for most workloads.
+  to the baseline. They are the quality-first choices among the local TQ
+  methods, but their current unfused fallback is intended for offline or
+  memory-constrained workloads rather than latency-sensitive serving.
 - `turboquant35` uses calibrated outlier dimensions (currently the
   fixed "first N dims as outliers" — calibrated metadata via
   `multi_turboquant.calibration` would improve quality further).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,8 +13,7 @@ The simplest way — load a model and call `.generate()`.
 
 ```python
 import os
-# Required env vars on Windows
-os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+# Keep single-rank Windows initialization on the loopback interface.
 os.environ["VLLM_HOST_IP"] = "127.0.0.1"
 
 # Make sure CUDA + torch DLLs are findable
@@ -24,24 +23,26 @@ os.add_dll_directory(r"C:\path\to\venv\Lib\site-packages\torch\lib")
 from vllm import LLM, SamplingParams
 
 llm = LLM(
-    model=r"E:\models\Qwen3-14B-AWQ-4bit",
+    model=r"E:\models\Qwen2.5-0.5B-Instruct",
     dtype="float16",
-    kv_cache_dtype="auto",          # or one of: isoquant3, isoquant4,
-                                    # planarquant3, planarquant4,
-                                    # turboquant25, turboquant35
-    max_model_len=2048,
-    gpu_memory_utilization=0.85,
-    enforce_eager=True,             # cudagraph capture is slow on Win
-    trust_remote_code=True,
+    kv_cache_dtype="auto",          # Fast baseline; model dtype for KV cache
+    max_model_len=512,
+    gpu_memory_utilization=0.5,
 )
 
-params = SamplingParams(temperature=0.7, max_tokens=200)
+params = SamplingParams(temperature=0.0, max_tokens=32, seed=0)
 outputs = llm.generate(
     ["Explain quantum entanglement to a 10-year-old:"],
     params,
 )
 print(outputs[0].outputs[0].text)
 ```
+
+Measure a second request in the same process so one-time kernel compilation or
+CUDA-graph capture is not counted as steady-state generation. If graph capture
+causes a compatibility problem, add `enforce_eager=True` temporarily; that
+setting disables `torch.compile` and CUDA graphs and therefore lowers
+throughput.
 
 ### Multi-GPU note
 
@@ -75,7 +76,7 @@ launch.bat --model E:\models\Qwen3-14B-AWQ-4bit --port 8000
 if Python, PyTorch, Triton, vLLM, or Triton's Python development files
 are missing.
 
-### Full options
+### Example with explicit overrides
 
 ```bat
 python vllm_launcher.py ^
@@ -85,22 +86,21 @@ python vllm_launcher.py ^
     --gpu-memory-utilization 0.85 ^
     --max-model-len 2048 ^
     --max-num-seqs 64 ^
-    --enforce-eager ^
     --trust-remote-code
 ```
 
 | Flag | Default | Notes |
 |---|---|---|
 | `--model` | (required) | Path to a HuggingFace-format model directory |
-| `--port` | 8000 | HTTP port |
+| `--port` | 8100 | HTTP port |
 | `--host` | 127.0.0.1 | Bind address |
-| `--gpu-memory-utilization` | 0.85 | Fraction of GPU memory to use |
-| `--max-model-len` | 2048 | Maximum context length |
+| `--gpu-memory-utilization` | 0.6 | Fraction of GPU memory to use |
+| `--max-model-len` | 8192 | Maximum context length; lower for small smoke tests |
 | `--max-num-seqs` | 64 | Concurrent request limit |
 | `--max-num-batched-tokens` | (auto) | Tokens per forward pass |
-| `--enforce-eager` | False | Skip CUDAGraph capture (recommended on Windows) |
-| `--gpu-id` | 0 | Which GPU to pin to (multi-GPU systems) |
-| `--enable-prefix-caching` | True | Cache common prompt prefixes |
+| `--enforce-eager` | False | Debug/compatibility option; disables compilation and CUDA graphs |
+| `--gpu-id` | (none) | Which GPU to pin to; otherwise preserve the current CUDA visibility |
+| `--enable-prefix-caching` | (not forced) | Explicitly enable common-prefix reuse; otherwise use vLLM's default |
 | `--task` | "generate" | "generate" or "embed" |
 | `--trust-remote-code` | False | Required for some models |
 
@@ -167,10 +167,9 @@ vLLM v0.24.0 ships an OpenAI-compatible server out of the box at
 ```bat
 vllm serve E:\models\Qwen3-14B-AWQ-4bit ^
     --dtype float16 ^
-    --kv-cache-dtype isoquant3 ^
+    --kv-cache-dtype auto ^
     --max-model-len 2048 ^
-    --gpu-memory-utilization 0.85 ^
-    --enforce-eager
+    --gpu-memory-utilization 0.6
 ```
 
 The `--kv-cache-dtype` flag accepts the 6 Multi-TurboQuant methods,
@@ -190,20 +189,20 @@ For a 24 GB GPU loading a 14B AWQ-4bit model:
 
 | Setting | Recommended | Why |
 |---|---|---|
-| `gpu_memory_utilization` | 0.85 | Leaves headroom for activations and Triton workspace |
+| `gpu_memory_utilization` | 0.6-0.85 | Start lower, then raise when the workload needs more KV capacity |
 | `max_model_len` | 2048-4096 | Larger contexts eat KV cache linearly |
 | `max_num_seqs` | 64-128 | Higher = more parallelism, more KV cache |
-| `enforce_eager` | True | CUDAGraph capture is slow + uses extra memory |
-| `kv_cache_dtype` | `auto` or `isoquant4` | iso4 doubles KV capacity at small quality cost |
+| `enforce_eager` | False | Normal optimized path; enable only to diagnose graph/compile problems |
+| `kv_cache_dtype` | `auto` | Fast baseline; use compressed KV only when capacity matters more than latency |
 
 For longer contexts, drop `max_num_seqs` to give each sequence more KV
 budget. For high concurrency, drop `max_model_len`.
 
 If you see `OutOfMemoryError`:
 1. Lower `gpu_memory_utilization` by 0.1
-2. Set `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`
-3. Switch to a TQ KV cache dtype to halve cache pressure
-4. Drop `max_num_seqs` and `max_model_len`
+2. Drop `max_num_seqs` and `max_model_len`
+3. Close other GPU processes and ensure the Windows pagefile is enabled
+4. Switch to a compressed KV dtype only if its documented throughput cost is acceptable
 
 ---
 
@@ -212,7 +211,7 @@ If you see `OutOfMemoryError`:
 | Method | When to use |
 |---|---|
 | `auto` (fp16) | Default. Best speed, most memory. |
-| `isoquant4` | **Recommended TQ**. Half the memory, near-FP16 quality, no calibration needed. |
+| `isoquant4` | Quality-first local TQ. Half the memory, but the current fallback is for offline/memory-first use. |
 | `planarquant4` | Same as iso4, simpler transform. |
 | `isoquant3` | Aggressive — 3.25 bits, visible quality loss. |
 | `planarquant3` | Same as iso3. |

--- a/tests/README.md
+++ b/tests/README.md
@@ -50,11 +50,9 @@ set VLLM_MODEL_PATH=E:\path\to\Qwen3-14B-AWQ-4bit
 set VLLM_PYTHON=E:\vllm-windows-build\venv\Scripts\python.exe
 ```
 
-And on Windows where the pagefile is small or disabled:
-
-```bat
-set PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
-```
+Keep the Windows pagefile enabled. Do not set
+`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`; the Windows PyTorch build
+reports that mode as unsupported.
 
 ## test_v19.py — smoke test
 
@@ -141,8 +139,11 @@ real numbers.
 - `test_tq_real.py` and `test_tq_thorough.py` spawn each method in a
   fresh subprocess to make sure GPU state from one run doesn't bleed
   into the next. This is slower but eliminates cross-test interference.
-- All tests use `enforce_eager=True` and `temperature=0.0` so output is
-  deterministic. Output diffs reflect KV math differences, not RNG.
+- The Multi-TurboQuant comparison tests use `enforce_eager=True` to hold
+  graph/compile behavior constant across methods and `temperature=0.0` so
+  output differences reflect KV math rather than RNG. The normal FP16 smoke
+  test keeps vLLM's optimized `enforce_eager=False` default unless
+  `VLLM_ENFORCE_EAGER=1` is set for troubleshooting.
 - The default settings (`max_model_len=512`, `gpu_memory_utilization=0.5`)
   fit comfortably on a single 24 GB RTX 3090 with the 14B AWQ-4bit
   model. Larger models or smaller GPUs will need adjustment.

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import re
 import unittest
 from pathlib import Path
@@ -18,6 +19,12 @@ def batch_settings(path: Path) -> dict[str, str]:
         if match:
             settings[match.group(1).upper()] = match.group(2)
     return settings
+
+
+def markdown_section(text: str, heading: str) -> str:
+    start = text.index(heading)
+    end = text.find("\n## ", start + len(heading))
+    return text[start:] if end == -1 else text[start:end]
 
 
 class ReleaseContractTests(unittest.TestCase):
@@ -81,6 +88,93 @@ class ReleaseContractTests(unittest.TestCase):
         self.assertIn(
             "+                _NP_INT64_MIN, _NP_INT64_MAX, dtype=np.int64",
             patch,
+        )
+
+    def test_quickstarts_use_fast_reproducible_baseline(self) -> None:
+        sections = {
+            "README.md": markdown_section(
+                (ROOT / "README.md").read_text(encoding="utf-8"),
+                "## Hello world",
+            ),
+            "VLLM.md": markdown_section(
+                (ROOT / "VLLM.md").read_text(encoding="utf-8"),
+                "## Hello World",
+            ),
+            "docs/usage.md": markdown_section(
+                (ROOT / "docs" / "usage.md").read_text(encoding="utf-8"),
+                "## (A) Python embedding",
+            ),
+        }
+        for name, section in sections.items():
+            with self.subTest(name=name):
+                snippet = section.split("```python", 1)[1].split("```", 1)[0]
+                ast.parse(snippet)
+                self.assertIn('kv_cache_dtype="auto"', section)
+                self.assertNotIn('kv_cache_dtype="isoquant4"', section)
+                self.assertIn("max_tokens=32", section)
+                self.assertIn("seed=0", section)
+                self.assertNotIn("PYTORCH_CUDA_ALLOC_CONF", section)
+
+    def test_launcher_defaults_are_documented_exactly(self) -> None:
+        launcher = (ROOT / "vllm_launcher.py").read_text(encoding="utf-8")
+        usage = (ROOT / "docs" / "usage.md").read_text(encoding="utf-8")
+        expected = (
+            (
+                'parser.add_argument("--port", type=int, default=8100)',
+                "| `--port` | 8100 |",
+            ),
+            (
+                'parser.add_argument("--max-model-len", type=int, default=8192,',
+                "| `--max-model-len` | 8192 |",
+            ),
+            (
+                'parser.add_argument("--gpu-memory-utilization", '
+                "type=float, default=0.6,",
+                "| `--gpu-memory-utilization` | 0.6 |",
+            ),
+            (
+                'parser.add_argument("--gpu-id", type=int, default=None,',
+                "| `--gpu-id` | (none) |",
+            ),
+        )
+        for code_default, documented_default in expected:
+            self.assertIn(code_default, launcher)
+            self.assertIn(documented_default, usage)
+
+    def test_windows_docs_do_not_enable_unsupported_expandable_segments(
+        self,
+    ) -> None:
+        paths = (
+            ROOT / "README.md",
+            ROOT / "VLLM.md",
+            ROOT / "build.bat",
+            ROOT / "docs" / "benchmarks.md",
+            ROOT / "docs" / "install.md",
+            ROOT / "docs" / "usage.md",
+            ROOT / "tests" / "README.md",
+            ROOT / "tests" / "test_tq_real.py",
+            ROOT / "tests" / "test_tq_thorough.py",
+            ROOT / "tests" / "test_v19.py",
+        )
+        for path in paths:
+            with self.subTest(path=path.relative_to(ROOT).as_posix()):
+                text = path.read_text(encoding="utf-8")
+                self.assertNotIn(
+                    "set PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True",
+                    text,
+                )
+                self.assertNotIn(
+                    'os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", '
+                    '"expandable_segments:True")',
+                    text,
+                )
+
+        troubleshooting = (ROOT / "docs" / "troubleshooting.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(
+            "expandable_segments not supported on this platform",
+            troubleshooting,
         )
 
 

--- a/tests/test_tq_real.py
+++ b/tests/test_tq_real.py
@@ -50,8 +50,6 @@ PROMPTS = [
 RUNNER_SCRIPT = r'''
 import faulthandler, os, sys, json
 faulthandler.enable()
-# Required on Windows when pagefile is small or disabled.
-os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
 _cuda_bin = os.environ.get(
     "CUDA_HOME",
     r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8",
@@ -72,7 +70,7 @@ llm = LLM(
     max_num_seqs=4,
     max_num_batched_tokens=512,
     gpu_memory_utilization=0.5,
-    enforce_eager=True,
+    enforce_eager=True,  # Hold graph/compile behavior constant across methods.
     trust_remote_code=True,
 )
 

--- a/tests/test_tq_thorough.py
+++ b/tests/test_tq_thorough.py
@@ -60,7 +60,6 @@ MAX_TOKENS = 80
 RUNNER_SCRIPT = r'''
 import faulthandler, os, sys, json, time
 faulthandler.enable()
-os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
 _cuda_bin = os.environ.get(
     "CUDA_HOME",
     r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8",
@@ -85,7 +84,7 @@ llm = LLM(
     max_num_seqs=8,            # try to fit all 8 prompts at once
     max_num_batched_tokens=512,
     gpu_memory_utilization=0.5,
-    enforce_eager=True,
+    enforce_eager=True,  # Hold graph/compile behavior constant across methods.
     trust_remote_code=True,
 )
 load_secs = time.perf_counter() - t0

--- a/tests/test_v19.py
+++ b/tests/test_v19.py
@@ -4,13 +4,10 @@ Configuration via environment variables (set before running):
     VLLM_MODEL_PATH       Path to a Qwen3 / Llama / similar model.
                           Default: None (you must set it).
     CUDA_VISIBLE_DEVICES  GPU index to pin to (default: 0).
-    PYTORCH_CUDA_ALLOC_CONF
-                          Should be 'expandable_segments:True' on Windows
-                          if your pagefile is small/disabled.
+    VLLM_ENFORCE_EAGER    Set to 1 only for graph/compile troubleshooting.
 
 Example:
     set VLLM_MODEL_PATH=E:\\models\\Qwen3-14B-AWQ-4bit
-    set PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
     python tests\\test_v19.py
 """
 import faulthandler
@@ -19,7 +16,6 @@ import os
 import sys
 
 # Set sane defaults for Windows
-os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
 os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
 os.environ.setdefault("CUDA_DEVICE_ORDER", "PCI_BUS_ID")
 os.environ.setdefault("CUDA_VISIBLE_DEVICES", "0")
@@ -33,6 +29,7 @@ if os.path.isdir(_CUDA_BIN):
     os.add_dll_directory(_CUDA_BIN)
 
 MODEL = os.environ.get("VLLM_MODEL_PATH")
+ENFORCE_EAGER = os.environ.get("VLLM_ENFORCE_EAGER", "0") == "1"
 if not MODEL:
     print("ERROR: set VLLM_MODEL_PATH to your model directory.")
     sys.exit(1)
@@ -51,15 +48,15 @@ llm = LLM(
     kv_cache_dtype="auto",
     max_model_len=int(os.environ.get("VLLM_MAX_MODEL_LEN", "2048")),
     gpu_memory_utilization=float(os.environ.get("VLLM_GPU_MEM_UTIL", "0.5")),
-    enforce_eager=True,
+    enforce_eager=ENFORCE_EAGER,
     trust_remote_code=True,
 )
 
 print("\nModel loaded successfully")
 
 sampling_params = SamplingParams(
-    temperature=0.7,
-    max_tokens=50,
+    temperature=0.0,
+    max_tokens=32,
     seed=0,
 )
 


### PR DESCRIPTION
﻿## Summary

- make `kv_cache_dtype="auto"` the reproducible fast baseline in every Hello World example
- label local Multi-TurboQuant modes as memory-first/offline paths instead of general defaults
- document `enforce_eager=True` as a compatibility/debugging override that disables normal optimizations
- synchronize the usage table with the actual `vllm_launcher.py` defaults
- remove the unsupported Windows `expandable_segments` recommendation
- add slow-generation troubleshooting and regression guards for future documentation drift

## Root cause

The performance follow-up in issue #10 copied the repository's README example. That example explicitly selected `isoquant4` and `enforce_eager=True`, even though the same documentation records a 30-300x throughput penalty for the unfused local Multi-TurboQuant encode/decode fallback. The reported 200-token runtime at 0.28 output tokens/s is consistent with that known path, not normal vLLM baseline performance.

The quick start now uses a small model, FP16 `auto` KV cache, deterministic 32-token sampling, and normal optimized execution. Multi-TurboQuant remains available with its memory/latency trade-off stated next to the option.

Related to #10. No wheel or release binary changes are required.

## Validation

- `python -m unittest tests.test_verify_artifact tests.test_bootstrap_helpers tests.test_engine_dispatcher tests.test_release_contract -v` ? 17 tests passed
- `python -m unittest tests.test_release_contract -v` ? 8 documentation/release contract tests passed
- `python -m py_compile tests/test_release_contract.py tests/test_v19.py tests/test_tq_real.py tests/test_tq_thorough.py` ? passed
- `git diff --check` ? passed
- regression tests parse all three maintained Python quick-start snippets with `ast.parse`

## AI assistance

OpenAI Codex was used to analyze the reporter's log, audit the maintained defaults and examples, implement the corrections, and run the validation above. The commit includes an `Assisted-by` trailer.
